### PR TITLE
Fix puml diagrams and rename to rolebook

### DIFF
--- a/docs/diagrams/ArchitectureSequenceDiagram.puml
+++ b/docs/diagrams/ArchitectureSequenceDiagram.puml
@@ -19,7 +19,7 @@ activate model MODEL_COLOR
 model -[MODEL_COLOR]-> logic
 deactivate model
 
-logic -[LOGIC_COLOR]> storage : saveAddressBook(addressBook)
+logic -[LOGIC_COLOR]> storage : saveRoleBook(RoleBook)
 activate storage STORAGE_COLOR
 
 storage -[STORAGE_COLOR]> storage : Save to file

--- a/docs/diagrams/BetterModelClassDiagram.puml
+++ b/docs/diagrams/BetterModelClassDiagram.puml
@@ -4,8 +4,8 @@ skinparam arrowThickness 1.1
 skinparam arrowColor MODEL_COLOR
 skinparam classBackgroundColor MODEL_COLOR
 
-AddressBook *-right-> "1" UniqueRoleList
-AddressBook *-right-> "1" UniqueTagList
+RoleBook *-right-> "1" UniqueRoleList
+RoleBook *-right-> "1" UniqueTagList
 UniqueTagList -[hidden]down- UniqueRoleList
 UniqueTagList -[hidden]down- UniqueRoleList
 

--- a/docs/diagrams/CommitActivityDiagram.puml
+++ b/docs/diagrams/CommitActivityDiagram.puml
@@ -5,10 +5,10 @@ start
 'Since the beta syntax does not support placing the condition outside the
 'diamond we place it as the true branch instead.
 
-if () then ([command commits AddressBook])
+if () then ([command commits RoleBook])
     :Purge redundant states;
-    :Save AddressBook to
-    addressBookStateList;
+    :Save RoleBook to
+    RoleBookStateList;
 else ([else])
 endif
 stop

--- a/docs/diagrams/CompanyCommand.puml
+++ b/docs/diagrams/CompanyCommand.puml
@@ -3,7 +3,7 @@
 
 box Logic LOGIC_COLOR_T1
 participant ":LogicManager" as LogicManager LOGIC_COLOR
-participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":RoleBookParser" as RoleBookParser LOGIC_COLOR
 participant ":CompanyCommandParser" as CompanyCommandParser LOGIC_COLOR
 participant ":CompanyCommand" as CompanyCommand LOGIC_COLOR
 participant ":CompanyContainsKeywordsPredicate" as CompanyContainsKeywordsPredicate LOGIC_COLOR
@@ -18,17 +18,17 @@ end box
 [-> LogicManager : execute("company Google")
 activate LogicManager
 
-LogicManager -> AddressBookParser : parseCommand("company Google")
-activate AddressBookParser
+LogicManager -> RoleBookParser : parseCommand("company Google")
+activate RoleBookParser
 
 create CompanyCommandParser
-AddressBookParser -> CompanyCommandParser
+RoleBookParser -> CompanyCommandParser
 activate CompanyCommandParser
 
-CompanyCommandParser --> AddressBookParser
+CompanyCommandParser --> RoleBookParser
 deactivate CompanyCommandParser
 
-AddressBookParser -> CompanyCommandParser : parse("Google")
+RoleBookParser -> CompanyCommandParser : parse("Google")
 activate CompanyCommandParser
 
 create CompanyCommand
@@ -46,14 +46,14 @@ CompanyContainsKeywordsPredicate --> CompanyCommand
 deactivate CompanyContainsKeywordsPredicate
 
 
-CompanyCommandParser --> AddressBookParser
+CompanyCommandParser --> RoleBookParser
 deactivate CompanyCommandParser
 'Hidden arrow to position the destroy marker below the end of the activation bar.
-CompanyCommandParser -[hidden]-> AddressBookParser
+CompanyCommandParser -[hidden]-> RoleBookParser
 destroy CompanyCommandParser
 
-AddressBookParser --> LogicManager
-deactivate AddressBookParser
+RoleBookParser --> LogicManager
+deactivate RoleBookParser
 
 
 LogicManager -> CompanyCommand : execute(model)

--- a/docs/diagrams/DeadlineCommandSequenceDiagram.puml
+++ b/docs/diagrams/DeadlineCommandSequenceDiagram.puml
@@ -3,7 +3,7 @@
 
 box Logic LOGIC_COLOR_T1
 participant ":LogicManager" as LogicManager LOGIC_COLOR
-participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":RoleBookParser" as RoleBookParser LOGIC_COLOR
 participant ":DeadlineCommandParser" as DeadlineCommandParser LOGIC_COLOR
 participant "s:DeadlineCommand" as DeadlineCommand LOGIC_COLOR
 participant "o:Order" as Order LOGIC_COLOR
@@ -18,17 +18,17 @@ end box
 [-> LogicManager : execute("deadline asc")
 activate LogicManager
 
-LogicManager -> AddressBookParser : parseCommand("deadline asc")
-activate AddressBookParser
+LogicManager -> RoleBookParser : parseCommand("deadline asc")
+activate RoleBookParser
 
 create DeadlineCommandParser
-AddressBookParser -> DeadlineCommandParser
+RoleBookParser -> DeadlineCommandParser
 activate DeadlineCommandParser
 
-DeadlineCommandParser --> AddressBookParser
+DeadlineCommandParser --> RoleBookParser
 deactivate DeadlineCommandParser
 
-AddressBookParser -> DeadlineCommandParser : parse("asc")
+RoleBookParser -> DeadlineCommandParser : parse("asc")
 activate DeadlineCommandParser
 
 create DeadlineCommand
@@ -46,14 +46,14 @@ Order --> DeadlineCommand : o
 deactivate Order
 
 
-DeadlineCommandParser --> AddressBookParser : s
+DeadlineCommandParser --> RoleBookParser : s
 deactivate DeadlineCommandParser
 'Hidden arrow to position the destroy marker below the end of the activation bar.
-DeadlineCommandParser -[hidden]-> AddressBookParser
+DeadlineCommandParser -[hidden]-> RoleBookParser
 destroy DeadlineCommandParser
 
-AddressBookParser --> LogicManager : s
-deactivate AddressBookParser
+RoleBookParser --> LogicManager : s
+deactivate RoleBookParser
 
 
 LogicManager -> DeadlineCommand : execute()

--- a/docs/diagrams/DeleteSequenceDiagram.puml
+++ b/docs/diagrams/DeleteSequenceDiagram.puml
@@ -3,7 +3,7 @@
 
 box Logic LOGIC_COLOR_T1
 participant ":LogicManager" as LogicManager LOGIC_COLOR
-participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":RoleBookParser" as RoleBookParser LOGIC_COLOR
 participant ":DeleteCommandParser" as DeleteCommandParser LOGIC_COLOR
 participant "d:DeleteCommand" as DeleteCommand LOGIC_COLOR
 participant ":CommandResult" as CommandResult LOGIC_COLOR
@@ -16,17 +16,17 @@ end box
 [-> LogicManager : execute("delete 1")
 activate LogicManager
 
-LogicManager -> AddressBookParser : parseCommand("delete 1")
-activate AddressBookParser
+LogicManager -> RoleBookParser : parseCommand("delete 1")
+activate RoleBookParser
 
 create DeleteCommandParser
-AddressBookParser -> DeleteCommandParser
+RoleBookParser -> DeleteCommandParser
 activate DeleteCommandParser
 
-DeleteCommandParser --> AddressBookParser
+DeleteCommandParser --> RoleBookParser
 deactivate DeleteCommandParser
 
-AddressBookParser -> DeleteCommandParser : parse("1")
+RoleBookParser -> DeleteCommandParser : parse("1")
 activate DeleteCommandParser
 
 create DeleteCommand
@@ -36,14 +36,14 @@ activate DeleteCommand
 DeleteCommand --> DeleteCommandParser : d
 deactivate DeleteCommand
 
-DeleteCommandParser --> AddressBookParser : d
+DeleteCommandParser --> RoleBookParser : d
 deactivate DeleteCommandParser
 'Hidden arrow to position the destroy marker below the end of the activation bar.
-DeleteCommandParser -[hidden]-> AddressBookParser
+DeleteCommandParser -[hidden]-> RoleBookParser
 destroy DeleteCommandParser
 
-AddressBookParser --> LogicManager : d
-deactivate AddressBookParser
+RoleBookParser --> LogicManager : d
+deactivate RoleBookParser
 
 LogicManager -> DeleteCommand : execute()
 activate DeleteCommand

--- a/docs/diagrams/LogicClassDiagram.puml
+++ b/docs/diagrams/LogicClassDiagram.puml
@@ -6,7 +6,7 @@ skinparam classBackgroundColor LOGIC_COLOR
 
 package Logic {
 
-Class AddressBookParser
+Class RoleBookParser
 Class XYZCommand
 Class CommandResult
 Class "{abstract}\nCommand" as Command
@@ -27,8 +27,8 @@ Class HiddenOutside #FFFFFF
 HiddenOutside ..> Logic
 
 LogicManager .right.|> Logic
-LogicManager -right->"1" AddressBookParser
-AddressBookParser ..> XYZCommand : creates >
+LogicManager -right->"1" RoleBookParser
+RoleBookParser ..> XYZCommand : creates >
 
 XYZCommand -up-|> Command
 LogicManager .left.> Command : executes >

--- a/docs/diagrams/ModelClassDiagram.puml
+++ b/docs/diagrams/ModelClassDiagram.puml
@@ -5,10 +5,10 @@ skinparam arrowColor MODEL_COLOR
 skinparam classBackgroundColor MODEL_COLOR
 
 Package Model <<Rectangle>>{
-Class "<<interface>>\nReadOnlyAddressBook" as ReadOnlyAddressBook
+Class "<<interface>>\nReadOnlyRoleBook" as ReadOnlyRoleBook
 Class "<<interface>>\nReadOnlyUserPrefs" as ReadOnlyUserPrefs
-Class "<<interface>>\nModel" as Model
-Class AddressBook
+Class "<<interface>>\nModel" as Model2
+Class RoleBook
 Class ModelManager
 Class UserPrefs
 
@@ -28,19 +28,19 @@ Class Experience
 }
 
 Class HiddenOutside #FFFFFF
-HiddenOutside ..> Model
+HiddenOutside ..> Model2
 
-AddressBook .up.|> ReadOnlyAddressBook
+RoleBook .up.|> ReadOnlyRoleBook
 
-ModelManager .up.|> Model
-Model .right.> ReadOnlyUserPrefs
-Model .left.> ReadOnlyAddressBook
-ModelManager -left-> "1" AddressBook
+ModelManager .up.|> Model2
+Model2 .right.> ReadOnlyUserPrefs
+Model2 .left.> ReadOnlyRoleBook
+ModelManager -left-> "1" RoleBook
 ModelManager -right-> "1" UserPrefs
 UserPrefs .up.|> ReadOnlyUserPrefs
 
-AddressBook *--> "1" UniqueRoleList
-UniqueRoleList --> "~* all" Role
+RoleBook *--> "1" UniqueRoleList
+
 Role *--> Name
 Role *--> Phone
 Role *--> Email
@@ -53,8 +53,9 @@ Role *--> JobDescription
 Role *--> Experience
 
 Name -[hidden]right-> Phone
-Phone -[hidden]right-> Address
-Address -[hidden]right-> Email
+Phone -[hidden]right-> Role
+Role -[hidden]right-> Email
 
 ModelManager -->"~* filtered" Role
+UniqueRoleList --> "~* all" Role
 @enduml

--- a/docs/diagrams/ParserClasses.puml
+++ b/docs/diagrams/ParserClasses.puml
@@ -9,7 +9,7 @@ Class XYZCommand
 
 package "Parser classes"{
 Class "<<interface>>\nParser" as Parser
-Class AddressBookParser
+Class RoleBookParser
 Class XYZCommandParser
 Class CliSyntax
 Class ParserUtil
@@ -19,12 +19,12 @@ Class Prefix
 }
 
 Class HiddenOutside #FFFFFF
-HiddenOutside ..> AddressBookParser
+HiddenOutside ..> RoleBookParser
 
-AddressBookParser .down.> XYZCommandParser: creates >
+RoleBookParser .down.> XYZCommandParser: creates >
 
 XYZCommandParser ..> XYZCommand : creates >
-AddressBookParser ..> Command : returns >
+RoleBookParser ..> Command : returns >
 XYZCommandParser .up.|> Parser
 XYZCommandParser ..> ArgumentMultimap
 XYZCommandParser ..> ArgumentTokenizer

--- a/docs/diagrams/SalaryCommandSequenceDiagram.puml
+++ b/docs/diagrams/SalaryCommandSequenceDiagram.puml
@@ -3,7 +3,7 @@
 
 box Logic LOGIC_COLOR_T1
 participant ":LogicManager" as LogicManager LOGIC_COLOR
-participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":RoleBookParser" as RoleBookParser LOGIC_COLOR
 participant ":SalaryCommandParser" as SalaryCommandParser LOGIC_COLOR
 participant "s:SalaryCommand" as SalaryCommand LOGIC_COLOR
 participant "o:Order" as Order LOGIC_COLOR
@@ -18,17 +18,17 @@ end box
 [-> LogicManager : execute("salary asc")
 activate LogicManager
 
-LogicManager -> AddressBookParser : parseCommand("salary asc")
-activate AddressBookParser
+LogicManager -> RoleBookParser : parseCommand("salary asc")
+activate RoleBookParser
 
 create SalaryCommandParser
-AddressBookParser -> SalaryCommandParser
+RoleBookParser -> SalaryCommandParser
 activate SalaryCommandParser
 
-SalaryCommandParser --> AddressBookParser
+SalaryCommandParser --> RoleBookParser
 deactivate SalaryCommandParser
 
-AddressBookParser -> SalaryCommandParser : parse("asc")
+RoleBookParser -> SalaryCommandParser : parse("asc")
 activate SalaryCommandParser
 
 create SalaryCommand
@@ -46,14 +46,14 @@ Order --> SalaryCommand : o
 deactivate Order
 
 
-SalaryCommandParser --> AddressBookParser : s
+SalaryCommandParser --> RoleBookParser : s
 deactivate SalaryCommandParser
 'Hidden arrow to position the destroy marker below the end of the activation bar.
-SalaryCommandParser -[hidden]-> AddressBookParser
+SalaryCommandParser -[hidden]-> RoleBookParser
 destroy SalaryCommandParser
 
-AddressBookParser --> LogicManager : s
-deactivate AddressBookParser
+RoleBookParser --> LogicManager : s
+deactivate RoleBookParser
 
 
 LogicManager -> SalaryCommand : execute()

--- a/docs/diagrams/StorageClassDiagram.puml
+++ b/docs/diagrams/StorageClassDiagram.puml
@@ -11,13 +11,13 @@ Class "<<interface>>\nUserPrefsStorage" as UserPrefsStorage
 Class JsonUserPrefsStorage
 }
 
-Class "<<interface>>\nStorage" as Storage
+Class "<<interface>>\nStorage" as Storage2
 Class StorageManager
 
-package "AddressBook Storage" #F4F6F6{
-Class "<<interface>>\nAddressBookStorage" as AddressBookStorage
-Class JsonAddressBookStorage
-Class JsonSerializableAddressBook
+package "RoleBook Storage" #F4F6F6{
+Class "<<interface>>\nRoleBookStorage" as RoleBookStorage
+Class JsonRoleBookStorage
+Class JsonSerializableRoleBook
 Class JsonAdaptedRole
 Class JsonAdaptedTag
 }
@@ -25,19 +25,19 @@ Class JsonAdaptedTag
 }
 
 Class HiddenOutside #FFFFFF
-HiddenOutside ..> Storage
+HiddenOutside ..> Storage2
 
-StorageManager .up.|> Storage
+StorageManager .up.|> Storage2
 StorageManager -up-> "1" UserPrefsStorage
-StorageManager -up-> "1" AddressBookStorage
+StorageManager -up-> "1" RoleBookStorage
 
-Storage -left-|> UserPrefsStorage
-Storage -right-|> AddressBookStorage
+Storage2 -left-|> UserPrefsStorage
+Storage2 -right-|> RoleBookStorage
 
 JsonUserPrefsStorage .up.|> UserPrefsStorage
-JsonAddressBookStorage .up.|> AddressBookStorage
-JsonAddressBookStorage ..> JsonSerializableAddressBook
-JsonSerializableAddressBook --> "*" JsonAdaptedRole
+JsonRoleBookStorage .up.|> RoleBookStorage
+JsonRoleBookStorage ..> JsonSerializableRoleBook
+JsonSerializableRoleBook --> "*" JsonAdaptedRole
 JsonAdaptedRole --> "*" JsonAdaptedTag
 
 @enduml

--- a/docs/diagrams/TagCommand.puml
+++ b/docs/diagrams/TagCommand.puml
@@ -3,7 +3,7 @@
 
 box Logic LOGIC_COLOR_T1
 participant ":LogicManager" as LogicManager LOGIC_COLOR
-participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":RoleBookParser" as RoleBookParser LOGIC_COLOR
 participant ":TagCommandParser" as TagCommandParser LOGIC_COLOR
 participant ":TagCommand" as TagCommand LOGIC_COLOR
 participant ":TagContainsKeywordsPredicate" as TagContainsKeywordsPredicate LOGIC_COLOR
@@ -18,17 +18,17 @@ end box
 [-> LogicManager : execute("tag Tech")
 activate LogicManager
 
-LogicManager -> AddressBookParser : parseCommand("tag Tech")
-activate AddressBookParser
+LogicManager -> RoleBookParser : parseCommand("tag Tech")
+activate RoleBookParser
 
 create TagCommandParser
-AddressBookParser -> TagCommandParser
+RoleBookParser -> TagCommandParser
 activate TagCommandParser
 
-TagCommandParser --> AddressBookParser
+TagCommandParser --> RoleBookParser
 deactivate TagCommandParser
 
-AddressBookParser -> TagCommandParser : parse("Tech")
+RoleBookParser -> TagCommandParser : parse("Tech")
 activate TagCommandParser
 
 create TagCommand
@@ -46,14 +46,14 @@ TagContainsKeywordsPredicate --> TagCommand
 deactivate TagContainsKeywordsPredicate
 
 
-TagCommandParser --> AddressBookParser
+TagCommandParser --> RoleBookParser
 deactivate TagCommandParser
 'Hidden arrow to position the destroy marker below the end of the activation bar.
-TagCommandParser -[hidden]-> AddressBookParser
+TagCommandParser -[hidden]-> RoleBookParser
 destroy TagCommandParser
 
-AddressBookParser --> LogicManager
-deactivate AddressBookParser
+RoleBookParser --> LogicManager
+deactivate RoleBookParser
 
 
 LogicManager -> TagCommand : execute(model)


### PR DESCRIPTION
This PR will fix the puml bugs that caused wrong diagrams to be produced after refactoring of various names.
Additionally, AddressBook has been refactored to RoleBook in the puml files for consistency. This partly updates the DG for issue #159.